### PR TITLE
Correções nos ícones SVG para melhorar a acessibilidade

### DIFF
--- a/Leonora/assets/sprite.svg
+++ b/Leonora/assets/sprite.svg
@@ -1,19 +1,17 @@
 <svg xmlns="http://www.w3.org/2000/svg" style="display: none;">
 
-  <symbol id="icone-avatar" viewBox="0 0 100 100">
-    <circle cx="50" cy="50" r="50"/>
-  </symbol>
+    <symbol id="icone-avatar" viewBox="0 0 24 24">
+        <title>Ícone para inserção de foto ou avatar da usuária</title>
+        <circle cx="12" cy="12" r="12"/>
+    </symbol>
 
-  <symbol id="separador-breadcrumb" viewBox="0 0 8 16">
-    <path d="M1 1l6 7-6 7" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round"/>
-  </symbol>
-  
-  <symbol id="icone-botao-download" viewBox="0 0 24 24">
-    <path d="M12 15l-5-5h3V3h4v7h3l-5 5zM20 18H4v-2h16v2z"/>
-  </symbol>
+    <symbol id="icone-botao-download" viewBox="0 0 17 17">
+        <title>Ícone sinalizador de material para download</title>
+        <path d="M16.15 10.2c-.23 0-.44.09-.6.25s-.3.38-.3.6v3.4c0 .22-.09.44-.25.6s-.38.25-.6.25H2.55c-.22 0-.44-.09-.6-.25s-.25-.38-.25-.6v-3.4c0-.22-.09-.44-.25-.6S1.07 10.2.85 10.2c-.22 0-.44.09-.6.25S0 10.82 0 11.05v3.4c0 .68.27 1.33.75 1.81s1.13.75 1.8.75h11.9c.68 0 1.33-.27 1.8-.75s.75-1.13.75-1.81v-3.4c0-.23-.09-.44-.25-.6s-.37-.25-.6-.25z M7.9 11.65c.16.16.38.25.6.25s.44-.09.6-.25l3.4-3.4c.16-.16.25-.38.25-.6s-.09-.44-.25-.6c-.32-.32-.88-.32-1.2 0L9.35 9V.85C9.35.39 8.96 0 8.5 0s-.85.39-.85.85V9L5.7 7.05c-.32-.32-.88-.32-1.2 0s-.32.88 0 1.2l3.4 3.4z"/>
+    </symbol>
 
-  <symbol id="icone-abrir-modulo" viewBox="0 0 8 16">
-      <path d="M1 1l6 7-6 7" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round"/>
-  </symbol>
-
+    <symbol id="icone-abrir-modulo" viewBox="0 0 16 9">
+        <title>Ícone de chevron para abrir e fechar seções da página</title>
+        <path d="M1 1L8 8L15 1" fill="none"/>
+    </symbol>
 </svg>

--- a/Leonora/index.html
+++ b/Leonora/index.html
@@ -31,17 +31,8 @@
     <nav class="breadcrumb" aria-label="breadcrumb"> <!--Sinaliza para o navegador que é um breadcrumb-->
         <ol>
             <li><a href="#">Início</a></li>
-            <li><svg class="separador-breadcrumb" aria-hidden="true">
-                    <use href="assets/sprite.svg#separador-breadcrumb"></use>
-            </svg></li>
             <li><a href="#" aria-current="page">Trilhas de Estudo</a></li>
-            <li><svg class="separador-breadcrumb" aria-hidden="true">
-                    <use href="assets/sprite.svg#separador-breadcrumb"></use>
-            </svg></li>
             <li><a href="#">Submeter Atividades</a></li>
-            <li><svg class="separador-breadcrumb">
-                    <use href="assets/sprite.svg#separador-breadcrumb"></use>
-            </svg></li>
             <li><a href="#">Agenda</a></li>
         </ol>
     </nav>
@@ -103,7 +94,9 @@
             <section class="area-modulo">
                 <div class="barra-acesso-modulo">
                     <h3 class="titulo-modulo">Módulo 2: CSS Avançado</h3>
-                    <svg class="icone-abrir-modulo" aria-hidden="true"><use href="assets/sprite.svg#icone-abrir-modulo"></use></svg>
+                    <button class="btn-abrir-modulo" aria-label="Abrir nova seção da página">
+                        <svg class="icone-abrir-modulo" aria-hidden="true">
+                            <use href="assets/sprite.svg#icone-abrir-modulo"></use></svg></button>
                 </div>
                 <div class="informacoes-modulo">
                     <p class="descricao-trilha">Em breve...</p>

--- a/Leonora/style.css
+++ b/Leonora/style.css
@@ -49,8 +49,8 @@ body {
 .icone-avatar {
     fill: #F4D7F5;
     width: 40px;
-    aspect-ratio: 1/1;
-    flex-shrink: 0;
+    height: 40px;
+    border-radius: 50%;
 }
 
 .nome-user {
@@ -87,15 +87,6 @@ body {
     text-decoration-thickness: auto;
     text-underline-offset: auto;
     text-underline-position: from-font;
-}
-
-.separador-breadcrumb {
-    stroke: #3C254D;
-    stroke-width: 1px;
-    width:8px;
-    height: 16px;
-    flex-shrink: 0;
-    vertical-align: middle;
 }
 
 .titulos-principais {
@@ -140,6 +131,7 @@ body {
     margin: 12px;
     padding-inline: 12px;
     flex-shrink: 0;
+    cursor: pointer;
 }
 
 .nome-botao {
@@ -262,7 +254,6 @@ body {
     fill: #FFFAFC;
     width: 17px;
     height: 17px;
-    flex-shrink: 0;
 }
 
 .descricao-botao-download {
@@ -290,12 +281,23 @@ body {
     align-items: center;
 }
 
+btn-abrir-modulo {
+    appearance: none;
+    border: none;
+    background: transparent;
+    display: inline-block;
+    line-height: 0;
+    padding: 8px;
+    cursor: pointer;
+}
+
 .icone-abrir-modulo {
     stroke: #C89FF2;
-    stroke-width: 1px;
+    stroke-width: 2;
+    stroke-linecap: round;
+    stroke-linejoin: round;
     width: 12px;
-    aspect-ratio: 1/2;
-    flex-shrink: 0;
+    height: auto;
     transition: transform 0.3s ease-in-out;
 }
 


### PR DESCRIPTION
<strong>O que foi feito:</strong>

- Revisão do arquivo `sprite.svg` e das inclusões dos ícones no HTML (com a tag `<use>`, já que o ícone para avatar da usuária não estava funcionando. <em>Observação:</em> Ainda estou reformulando partes do CSS - o breadcrumb ficará sem os ícones SVG, como combinado, e arrumarei o conflito que aconteceu na apresentação do ícone de abrir a seção do novo módulo.

- Foram adicionadas tags `<title>` no arquivo `sprite.svg` e `aria-label` no botão que está "encobrindo" o ícone de abrir novo módulo (que fiz para aumentar a área clicável). 

- Essas mudanças foram feitas para melhoria da acessibilidade da página.
